### PR TITLE
Add GIF for SOPE-Dex under publications

### DIFF
--- a/_data/pubs.yml
+++ b/_data/pubs.yml
@@ -75,7 +75,7 @@
 	  \ author = {Hao Jiang and Yuhai Wang and Hanyang Zhou and Daniel Seita}, \n
     \ booktitle = {International Symposium of Robotics Research (ISRR)},\n
     \ Year = {2024}\n}"
-  img: ../img/papers/placeholder_isrr.png
+  img: ../img/papers/SOPE-2024-ISRR.gif
   links:
     '[arXiv]': https://arxiv.org/abs/2409.00643
   short_id: 2024_SOPE


### PR DESCRIPTION
I added the GIF File for Learning to Singulate Objects in Packed Environments using a Dexterous Hand.

As I cannot preview the rendering webpage on my end, please make sure it loaded correctly after the merge.